### PR TITLE
Change Upstream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <upstream.version>1.5.1</upstream.version>
-        <upstream.url>https://github.com/DataTables/ColReorder/archive</upstream.url>
+        <upstream.url>https://datatables.net/releases/</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
         <requirejs>
             {
@@ -83,7 +83,7 @@
                         </goals>
                         <configuration>
                             <url>${upstream.url}</url>
-                            <fromFile>${upstream.version}.zip</fromFile>
+                            <fromFile>ColReorder-${upstream.version}.zip</fromFile>
                             <toFile>${project.build.directory}/${project.artifactId}.zip</toFile>
                         </configuration>
                     </execution>


### PR DESCRIPTION
This webjar only contains SCSS instead of CSS files. This is a problem for me, since I'd like to embed this in a website without first compiling the SCSS. Also there are no minified versions of the files.

On https://datatables.net/download/packages the download of zip files for the various datatables modules is possible, which include both CSS and minified files. Is it possible to switch the upstream from GitHub releases (where these are not included) to the datatables download page?